### PR TITLE
Add toggle scripts for RetroArch boolean settings

### DIFF
--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/audio_fastforward_mute.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/audio_fastforward_mute.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/toggle.sh" audio_fastforward_mute

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/content_show_history.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/content_show_history.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/toggle.sh" content_show_history

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/content_show_settings.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/content_show_settings.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/toggle.sh" content_show_settings

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/fps_show.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/fps_show.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/toggle.sh" fps_show

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/menu_show_configuration.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/menu_show_configuration.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/toggle.sh" menu_show_configuration

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/menu_show_load_content.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/menu_show_load_content.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/toggle.sh" menu_show_load_content

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/quick_menu_show_save_core_overrides.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/quick_menu_show_save_core_overrides.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/toggle.sh" quick_menu_show_save_core_overrides

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/quick_menu_show_save_game_overrides.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/quick_menu_show_save_game_overrides.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/toggle.sh" quick_menu_show_save_game_overrides

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/quick_menu_show_shaders.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/quick_menu_show_shaders.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/toggle.sh" quick_menu_show_shaders

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/quick_menu_show_undo_save_load_state.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/quick_menu_show_undo_save_load_state.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/toggle.sh" quick_menu_show_undo_save_load_state

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/rgbpi_restrict_ui.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/rgbpi_restrict_ui.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/toggle.sh" rgbpi_restrict_ui

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/settings_show_configuration.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/settings_show_configuration.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/toggle.sh" settings_show_configuration

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/settings_show_user_interface.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/settings_show_user_interface.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/toggle.sh" settings_show_user_interface

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/toggle.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/toggle.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DRIVE="$(echo "$SCRIPT_DIR" | cut -d'/' -f3)"
+GLOBAL_CFG="/media/$DRIVE/gameconfig/sys_override/global.cfg"
+KEY="$1"
+
+if [ -z "$KEY" ]; then
+  echo "Usage: $0 <key>" >&2
+  exit 1
+fi
+
+if command -v crudini >/dev/null 2>&1; then
+  current=$(crudini --get "$GLOBAL_CFG" '' "$KEY" 2>/dev/null)
+  if [ "$current" = "true" ]; then new="false"; else new="true"; fi
+  crudini --set "$GLOBAL_CFG" '' "$KEY" "$new"
+else
+  line=$(grep -m1 "^$KEY" "$GLOBAL_CFG" || true)
+  current=$(echo "$line" | sed -e 's/.*= *"\?//' -e 's/"$//')
+  if [ "$current" = "true" ]; then new="false"; else new="true"; fi
+  sed -i "s/^$KEY\s*=\s*\"\?.*\"\?/$KEY = \"$new\"/" "$GLOBAL_CFG"
+fi

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/audio_fastforward_mute.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/audio_fastforward_mute.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/../toggle.sh" audio_fastforward_mute

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/content_show_history.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/content_show_history.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/../toggle.sh" content_show_history

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/content_show_settings.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/content_show_settings.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/../toggle.sh" content_show_settings

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/fps_show.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/fps_show.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/../toggle.sh" fps_show

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/menu_show_configuration.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/menu_show_configuration.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/../toggle.sh" menu_show_configuration

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/menu_show_load_content.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/menu_show_load_content.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/../toggle.sh" menu_show_load_content

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/quick_menu_show_save_core_overrides.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/quick_menu_show_save_core_overrides.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/../toggle.sh" quick_menu_show_save_core_overrides

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/quick_menu_show_save_game_overrides.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/quick_menu_show_save_game_overrides.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/../toggle.sh" quick_menu_show_save_game_overrides

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/quick_menu_show_shaders.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/quick_menu_show_shaders.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/../toggle.sh" quick_menu_show_shaders

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/quick_menu_show_undo_save_load_state.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/quick_menu_show_undo_save_load_state.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/../toggle.sh" quick_menu_show_undo_save_load_state

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/rgbpi_restrict_ui.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/rgbpi_restrict_ui.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/../toggle.sh" rgbpi_restrict_ui

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/settings_show_configuration.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/settings_show_configuration.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/../toggle.sh" settings_show_configuration

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/settings_show_user_interface.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/settings_show_user_interface.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/../toggle.sh" settings_show_user_interface

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/video_shader_enable.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo/video_shader_enable.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/../toggle.sh" video_shader_enable

--- a/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/video_shader_enable.sh
+++ b/RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/video_shader_enable.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/toggle.sh" video_shader_enable


### PR DESCRIPTION
## Summary
- add generic toggle.sh for RetroArch global.cfg booleans
- provide per-setting scripts and undo counterparts for each boolean option

## Testing
- `bash -n "RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/toggle.sh" && for f in "RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch"/*.sh "RGBPi-Extra/application/data/scripts/files/ui/mods/retroarch/undo"/*.sh; do bash -n "$f"; done`
- `python -m py_compile RGBPi-Extra/application/retroarch_settings.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5f862349c83329ae532b5124dceac