### PR TITLE
Add wrappers for RGBPi tweak scripts

### DIFF
--- a/mods/tweaks/General - Boot image sequence remove (reboots).bash
+++ b/mods/tweaks/General - Boot image sequence remove (reboots).bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_PATH="RGBPi-Extra/application/data/scripts/General - Boot image sequence remove (reboots).bash"
+bash "$REPO_ROOT/$SCRIPT_PATH" "$@"

--- a/mods/tweaks/General - Boot image sequence restore (reboots).bash
+++ b/mods/tweaks/General - Boot image sequence restore (reboots).bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_PATH="RGBPi-Extra/application/data/scripts/General - Boot image sequence restore (reboots).bash"
+bash "$REPO_ROOT/$SCRIPT_PATH" "$@"

--- a/mods/tweaks/General - Enable Boot Videos (reboots).bash
+++ b/mods/tweaks/General - Enable Boot Videos (reboots).bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_PATH="RGBPi-Extra/application/data/scripts/General - Enable Boot Videos (reboots).bash"
+bash "$REPO_ROOT/$SCRIPT_PATH" "$@"

--- a/mods/tweaks/General - Improve boot time (disables bluetooth).bash
+++ b/mods/tweaks/General - Improve boot time (disables bluetooth).bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_PATH="RGBPi-Extra/application/data/scripts/General - Improve boot time (disables bluetooth).bash"
+bash "$REPO_ROOT/$SCRIPT_PATH" "$@"

--- a/mods/tweaks/General - Improve boot time undo (enables bluetooth).bash
+++ b/mods/tweaks/General - Improve boot time undo (enables bluetooth).bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_PATH="RGBPi-Extra/application/data/scripts/General - Improve boot time undo (enables bluetooth).bash"
+bash "$REPO_ROOT/$SCRIPT_PATH" "$@"

--- a/mods/tweaks/General - Set correct 0777 permissions for Media.bash
+++ b/mods/tweaks/General - Set correct 0777 permissions for Media.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_PATH="RGBPi-Extra/application/data/scripts/General - Set correct 0777 permissions for Media.bash"
+bash "$REPO_ROOT/$SCRIPT_PATH" "$@"

--- a/mods/tweaks/Kodi - Fix Xbox gamepad issue (reboots).bash
+++ b/mods/tweaks/Kodi - Fix Xbox gamepad issue (reboots).bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_PATH="RGBPi-Extra/application/data/scripts/Kodi - Fix Xbox gamepad issue (reboots).bash"
+bash "$REPO_ROOT/$SCRIPT_PATH" "$@"

--- a/mods/tweaks/Kodi - Optimize UI for CRT (reboots).bash
+++ b/mods/tweaks/Kodi - Optimize UI for CRT (reboots).bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_PATH="RGBPi-Extra/application/data/scripts/Kodi - Optimize UI for CRT (reboots).bash"
+bash "$REPO_ROOT/$SCRIPT_PATH" "$@"

--- a/mods/tweaks/Retroarch - Arcade Freeplay disable.bash
+++ b/mods/tweaks/Retroarch - Arcade Freeplay disable.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_PATH="RGBPi-Extra/application/data/scripts/Retroarch - Arcade Freeplay disable.bash"
+bash "$REPO_ROOT/$SCRIPT_PATH" "$@"

--- a/mods/tweaks/Retroarch - Arcade Freeplay enable.bash
+++ b/mods/tweaks/Retroarch - Arcade Freeplay enable.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_PATH="RGBPi-Extra/application/data/scripts/Retroarch - Arcade Freeplay enable.bash"
+bash "$REPO_ROOT/$SCRIPT_PATH" "$@"

--- a/mods/tweaks/Retroarch - Change achievement sfx.bash
+++ b/mods/tweaks/Retroarch - Change achievement sfx.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_PATH="RGBPi-Extra/application/data/scripts/Retroarch - Change achievement sfx.bash"
+bash "$REPO_ROOT/$SCRIPT_PATH" "$@"

--- a/mods/tweaks/Retroarch - Menu 100 percent transparent.bash
+++ b/mods/tweaks/Retroarch - Menu 100 percent transparent.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_PATH="RGBPi-Extra/application/data/scripts/Retroarch - Menu 100 percent transparent.bash"
+bash "$REPO_ROOT/$SCRIPT_PATH" "$@"

--- a/mods/tweaks/Retroarch - Menu 50 percent transparent.bash
+++ b/mods/tweaks/Retroarch - Menu 50 percent transparent.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_PATH="RGBPi-Extra/application/data/scripts/Retroarch - Menu 50 percent transparent.bash"
+bash "$REPO_ROOT/$SCRIPT_PATH" "$@"

--- a/mods/tweaks/Retroarch - Menu default transparent.bash
+++ b/mods/tweaks/Retroarch - Menu default transparent.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_PATH="RGBPi-Extra/application/data/scripts/Retroarch - Menu default transparent.bash"
+bash "$REPO_ROOT/$SCRIPT_PATH" "$@"

--- a/mods/tweaks/Retroarch - Optimize core options.bash
+++ b/mods/tweaks/Retroarch - Optimize core options.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_PATH="RGBPi-Extra/application/data/scripts/Retroarch - Optimize core options.bash"
+bash "$REPO_ROOT/$SCRIPT_PATH" "$@"

--- a/mods/tweaks/Retroarch - Restore Default RA Options.bash
+++ b/mods/tweaks/Retroarch - Restore Default RA Options.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_PATH="RGBPi-Extra/application/data/scripts/Retroarch - Restore Default RA Options.bash"
+bash "$REPO_ROOT/$SCRIPT_PATH" "$@"


### PR DESCRIPTION
## Summary
- Add executable wrappers for all tweak scripts under `mods/tweaks`
- Wrappers call the original scripts in `RGBPi-Extra/application/data/scripts`

## Testing
- `bash -n mods/tweaks/*.bash`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5f86371188332b860428d9512d342